### PR TITLE
feat(tests): grade별 test 조회 페이지 생성

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/TestController.java
+++ b/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/TestController.java
@@ -1,0 +1,28 @@
+package com.example.ormi5finalteam1.controller.rest_controller;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import com.example.ormi5finalteam1.domain.test.TestQuestionResponseDto;
+import com.example.ormi5finalteam1.domain.user.Provider;
+import com.example.ormi5finalteam1.service.TestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TestController {
+
+    private final TestService testService;
+
+    @GetMapping("/tests")
+    public List<TestQuestionResponseDto> getTests(@AuthenticationPrincipal Provider provider,
+                                                  @RequestParam Grade grade) {
+        return testService.getTests(provider.grade(), grade);
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/test/Test.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/test/Test.java
@@ -1,4 +1,4 @@
-package com.example.ormi5finalteam1.domain.Tests;
+package com.example.ormi5finalteam1.domain.test;
 
 import com.example.ormi5finalteam1.domain.BaseEntity;
 import com.example.ormi5finalteam1.domain.Grade;
@@ -11,12 +11,13 @@ import lombok.*;
 @Table(name = "tests")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Tests extends BaseEntity {
+public class Test extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Grade grade;
 

--- a/src/main/java/com/example/ormi5finalteam1/domain/test/TestQuestionResponseDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/test/TestQuestionResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.ormi5finalteam1.domain.test;
+
+
+import com.example.ormi5finalteam1.domain.Grade;
+import lombok.*;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TestQuestionResponseDto {
+
+    private Grade grade;
+
+    private String question;
+
+    public static TestQuestionResponseDto toDto(Test test){
+        return TestQuestionResponseDto.builder()
+                .grade(test.getGrade())
+                .question(test.getQuestion())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/repository/TestRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/TestRepository.java
@@ -1,0 +1,17 @@
+package com.example.ormi5finalteam1.repository;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import com.example.ormi5finalteam1.domain.test.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TestRepository extends JpaRepository<Test, Long> {
+
+    List<Test> findByGrade(@Param("grade") Grade grade);
+
+
+}

--- a/src/main/java/com/example/ormi5finalteam1/service/TestService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/TestService.java
@@ -1,0 +1,27 @@
+package com.example.ormi5finalteam1.service;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import com.example.ormi5finalteam1.domain.test.Test;
+import com.example.ormi5finalteam1.domain.test.TestQuestionResponseDto;
+import com.example.ormi5finalteam1.repository.TestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TestService {
+
+    private final TestRepository testRepository;
+
+    public List<TestQuestionResponseDto> getTests(Grade userGrade, Grade grade) {
+
+        List<Test> gradeTestQuestions = testRepository.findByGrade(grade == null? userGrade : grade);
+
+        return gradeTestQuestions.stream()
+                .map(TestQuestionResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/com/example/ormi5finalteam1/entity/TestTest.java
+++ b/src/test/java/com/example/ormi5finalteam1/entity/TestTest.java
@@ -1,0 +1,49 @@
+package com.example.ormi5finalteam1.entity;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import com.example.ormi5finalteam1.domain.test.Test;
+import com.example.ormi5finalteam1.domain.test.TestQuestionResponseDto;
+import com.example.ormi5finalteam1.repository.TestRepository;
+import com.example.ormi5finalteam1.service.TestService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestTest {
+
+    @Mock
+    private TestRepository testRepository;
+
+    @InjectMocks
+    private TestService testService;
+
+    @org.junit.jupiter.api.Test
+    public void testQuestionCreation(){
+        Test question = new Test(1L, Grade.A2, "사과는 영어로?", "apple");
+
+        assertThat(question.getQuestion()).isEqualTo("사과는 영어로?");
+        assertThat(question.getGrade()).isEqualTo(Grade.A2);
+        assertThat(question.getAnswer()).isEqualTo("apple");
+    }
+
+    @org.junit.jupiter.api.Test
+    public void testQuestionRead() {
+        List<Test> questions= new ArrayList<>();
+        questions.add(new Test(1L, Grade.A2, "파인애플은 영어로?", "pineapple"));
+        questions.add(new Test(2L, Grade.A2, "바나나는 영어로?", "banana"));
+        when(testRepository.findByGrade(Grade.A2)).thenReturn(questions);
+
+        List<TestQuestionResponseDto> results = testService.getTests(Grade.A1, Grade.A2);
+        assertThat(results.get(0).getQuestion()).isEqualTo("파인애플은 영어로?");
+        assertThat(results.get(0).getGrade()).isEqualTo(Grade.A2);
+    }
+
+}


### PR DESCRIPTION
## 💡 이슈
resolve #18 

## 🤩 개요
레벨테스트 조회 기능 구현

## 🧑‍💻 작업 사항
- Provider 객체에서 현재 사용자의 grade를 받아와, null(가입 후 최초 레벨테스트 진행)이면 @RequestParam으로 받은 grade 값(사용자가 선택한 grade)으로 테스트 문제 조회
- 사용자의 grade가 null이 아니면(승급테스트) 현재 사용자의 grade로 테스트 문제 조회
- 문제의 grade와 문제를 반환하는 TestQuestionResponseDto 생성
- thymeleaf 사용을 위해 임시로 작성하였던 일반 controller와 html 파일 삭제

## 📖 참고 사항
- local DB 연결 전 test를 위해 Test 클래스를 생성하였습니다. 문제가 된다면 삭제하도록 하겠습니다.
