### PR TITLE
feat(essay): essay 가이드 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     USER_SUSPENDED(403, "User is suspended"),
     DUPLICATE_EMAIL(409, "Email is already in use"),
     DUPLICATE_NICKNAME(409, "Nickname is already in use"),
-    GRAMMAR_EXAMPLES_NOT_FOUND(404,"No grammar examples found");
+    GRAMMAR_EXAMPLES_NOT_FOUND(404,"No grammar examples found"),
+    ESSAY_NOT_FOUND(404,"Essay not found");
+
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/EssayController.java
+++ b/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/EssayController.java
@@ -1,24 +1,47 @@
 package com.example.ormi5finalteam1.controller.rest_controller;
 
-import com.example.ormi5finalteam1.domain.essay.dto.EssayRequestDto;
+import com.example.ormi5finalteam1.domain.essay.dto.request.EssayRequestDto;
+import com.example.ormi5finalteam1.domain.essay.dto.response.EssayGuideResponseDto;
 import com.example.ormi5finalteam1.service.EssayService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class EssayController {
 
     private final EssayService essayService;
 
-    @PostMapping("/api/essays")
-    public void createEssay(@Valid @RequestBody EssayRequestDto essayRequestDto) {
+    /** 에세이 생성 */
+    @PostMapping("/essays")
+    public ResponseEntity<Void> createEssay(@Valid @RequestBody EssayRequestDto essayRequestDto) {
         essayService.createEssay(essayRequestDto);
+        return new ResponseEntity<>(HttpStatusCode.valueOf(201));
     }
 
-    @PutMapping("/api/essays/{id}")
-    public void updateEssay(@PathVariable Long id, @Valid @RequestBody EssayRequestDto essayRequestDto) {
+    /** 에세이 수정 */
+    @PutMapping("/essays/{id}")
+    public ResponseEntity<Void> updateEssay(@PathVariable Long id, @Valid @RequestBody EssayRequestDto essayRequestDto) {
         essayService.updateEssay(id, essayRequestDto);
+        return new ResponseEntity<>(HttpStatusCode.valueOf(204));
+    }
+
+//    /** 에세이 첨삭 */
+//    @PutMapping("/essays/{id}/review")
+//    public void reviewEssay(@PathVariable Long id) {
+//        essayService.reviewEssay(id);
+//    }
+
+    /** 에세이 작성 가이드 조회 */
+    @GetMapping("/essay-guides")
+    public ResponseEntity<List<EssayGuideResponseDto>> showEssayGuide() {
+        List<EssayGuideResponseDto> essayGuideResponseDtoList = essayService.showEssayGuide();
+        return new ResponseEntity<>(essayGuideResponseDtoList, HttpStatusCode.valueOf(200));
     }
 }

--- a/src/main/java/com/example/ormi5finalteam1/domain/essay/EssayGuide.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/essay/EssayGuide.java
@@ -1,0 +1,27 @@
+package com.example.ormi5finalteam1.domain.essay;
+
+import com.example.ormi5finalteam1.domain.BaseEntity;
+import com.example.ormi5finalteam1.domain.Grade;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EssayGuide extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private Grade grade;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/essay/dto/request/EssayRequestDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/essay/dto/request/EssayRequestDto.java
@@ -1,4 +1,4 @@
-package com.example.ormi5finalteam1.domain.essay.dto;
+package com.example.ormi5finalteam1.domain.essay.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/example/ormi5finalteam1/domain/essay/dto/response/EssayGuideResponseDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/essay/dto/response/EssayGuideResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.ormi5finalteam1.domain.essay.dto.response;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EssayGuideResponseDto {
+    private Grade grade;
+    private String content;
+}

--- a/src/main/java/com/example/ormi5finalteam1/repository/EssayGuideRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/EssayGuideRepository.java
@@ -1,0 +1,7 @@
+package com.example.ormi5finalteam1.repository;
+
+import com.example.ormi5finalteam1.domain.essay.EssayGuide;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EssayGuideRepository extends JpaRepository<EssayGuide, Long> {
+}

--- a/src/main/java/com/example/ormi5finalteam1/service/EssayService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/EssayService.java
@@ -1,27 +1,38 @@
 package com.example.ormi5finalteam1.service;
 
 import com.example.ormi5finalteam1.domain.essay.Essay;
-import com.example.ormi5finalteam1.domain.essay.dto.EssayRequestDto;
+import com.example.ormi5finalteam1.domain.essay.EssayGuide;
+import com.example.ormi5finalteam1.domain.essay.dto.request.EssayRequestDto;
+import com.example.ormi5finalteam1.domain.essay.dto.response.EssayGuideResponseDto;
+import com.example.ormi5finalteam1.common.exception.BusinessException;
+import com.example.ormi5finalteam1.common.exception.ErrorCode;
 import com.example.ormi5finalteam1.domain.user.User;
+import com.example.ormi5finalteam1.repository.EssayGuideRepository;
 import com.example.ormi5finalteam1.repository.EssayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class EssayService {
 
     private final EssayRepository essayRepository;
+    private final EssayGuideRepository essayGuideRepository;
 
+    /** 에세이 생성 */
     public void createEssay(EssayRequestDto essayRequestDto) {
-        Essay essay = convertToEntity(essayRequestDto);
+        Essay essay = convertRequestToEntity(essayRequestDto);
         essayRepository.save(essay);
     }
 
+    /** 에세이 수정 */
     public void updateEssay(Long id, EssayRequestDto essayRequestDto) {
-        Essay essay = essayRepository.findById(id).orElseThrow(() -> new RuntimeException("Essay not found!"));
+        Essay essay = essayRepository.findById(id).orElseThrow(() -> new BusinessException(ErrorCode.ESSAY_NOT_FOUND));
 
-        Essay updatedEssay = essay.builder()
+        Essay updatedEssay = Essay.builder()
                 .id(id)
                 .user(essay.getUser())
                 .topic(essayRequestDto.topic())
@@ -30,8 +41,19 @@ public class EssayService {
         essayRepository.save(updatedEssay);
     }
 
+//    /** 에세이 첨삭 */
+//    public void reviewEssay(Long id) {
+//
+//    }
 
-    private Essay convertToEntity(EssayRequestDto essayRequestDto) {
+    /** 에세이 작성 가이드 조회 */
+    public List<EssayGuideResponseDto> showEssayGuide() {
+        return essayGuideRepository.findAll()
+                .stream()
+                .map(this::convertGuideResponseToDto).collect(Collectors.toList());
+    }
+
+    private Essay convertRequestToEntity(EssayRequestDto essayRequestDto) {
 
       return Essay.builder()
               .user(new User(essayRequestDto.userId()))
@@ -39,4 +61,12 @@ public class EssayService {
               .content(essayRequestDto.content())
               .build();
     }
+
+    private EssayGuideResponseDto convertGuideResponseToDto(EssayGuide essayGuide) {
+       return new EssayGuideResponseDto(
+               essayGuide.getGrade(),
+               essayGuide.getContent()
+       );
+    }
+
 }


### PR DESCRIPTION
## 💡 이슈
resolve #47

## 🤩 개요
에세이 작성 가이드 조회

## 🧑‍💻 작업 사항
EssayGuide Entity 생성
EssayGuideResponseDto 생성
Essay 패키지 수정 (requestDto, responseDto생성)
EssayGuideRepository 생성
EssayController, EssayService 조회 기능 구현

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
