### PR TITLE
fix(tests): 레벨/승급 테스트 조회 로직 수정

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(409, "Nickname is already in use"),
     GRAMMAR_EXAMPLES_NOT_FOUND(404,"No grammar examples found"),
     ESSAY_NOT_FOUND(404,"Essay not found"),
-    TEST_NOT_FOUND(404, "Test not found");
+    TEST_NOT_FOUND(404, "Test not found"),
+    CANNOT_TAKE_TEST(400, "Cannot take test");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/TestController.java
+++ b/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/TestController.java
@@ -18,10 +18,15 @@ public class TestController {
 
     private final TestService testService;
 
-    @GetMapping("/tests")
-    public List<TestQuestionResponseDto> getTests(@AuthenticationPrincipal Provider provider,
-                                                  @RequestParam Grade grade) {
-        return testService.getTests(provider.grade(), grade);
+    @GetMapping("/level-tests")
+    public List<TestQuestionResponseDto> getLevelTests(@AuthenticationPrincipal Provider provider,
+                                                  @RequestParam("grade") Grade selectedGrade) {
+        return testService.getLevelTests(selectedGrade);
+    }
+
+    @GetMapping("/upgrade-tests")
+    public List<TestQuestionResponseDto> getUpgradeTests(@AuthenticationPrincipal Provider provider) {
+        return testService.getUpgradeTests(provider);
     }
 
     @PostMapping("/grade")

--- a/src/main/java/com/example/ormi5finalteam1/domain/Grade.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/Grade.java
@@ -4,17 +4,23 @@ import lombok.Getter;
 
 @Getter
 public enum Grade {
-    A1("Bronze"),
-    A2("Silver"),
-    B1("Gold"),
-    B2("Platinum"),
-    C1("Diamond"),
-    C2("Challenger");
+    A1("Bronze", 0),
+    A2("Silver", 1),
+    B1("Gold", 2),
+    B2("Platinum", 3),
+    C1("Diamond", 4),
+    C2("Challenger", 5);
 
     private final String tier;
+    private final int index;
 
-    Grade(String tier) {
+    Grade(String tier, int index) {
         this.tier = tier;
+        this.index = index;
+    }
+
+    public int getIndex() {
+        return index;
     }
 
 }

--- a/src/main/java/com/example/ormi5finalteam1/domain/test/TestQuestionResponseDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/test/TestQuestionResponseDto.java
@@ -12,11 +12,14 @@ public class TestQuestionResponseDto {
 
     private Grade grade;
 
+    private Long testId;
+
     private String question;
 
     public static TestQuestionResponseDto toDto(Test test){
         return TestQuestionResponseDto.builder()
                 .grade(test.getGrade())
+                .testId(test.getId())
                 .question(test.getQuestion())
                 .build();
     }

--- a/src/main/java/com/example/ormi5finalteam1/service/TestService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/TestService.java
@@ -7,10 +7,14 @@ import com.example.ormi5finalteam1.domain.test.SubmitRequestDto;
 import com.example.ormi5finalteam1.domain.test.SubmitRequestVo;
 import com.example.ormi5finalteam1.domain.test.Test;
 import com.example.ormi5finalteam1.domain.test.TestQuestionResponseDto;
+import com.example.ormi5finalteam1.domain.user.Provider;
+import com.example.ormi5finalteam1.domain.user.User;
 import com.example.ormi5finalteam1.repository.TestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,14 +23,65 @@ import java.util.stream.Collectors;
 public class TestService {
 
     private final TestRepository testRepository;
+    private final UserService userService;
 
-    public List<TestQuestionResponseDto> getTests(Grade userGrade, Grade grade) {
+    /**
+     * 레벨 테스트 시 문제 조회
+     * A1은 시험 안 봄
+     * A2 ~ C1은 시험 존재
+     *
+     * @param selectedGrade 사용자가 선택한 등급
+     * @return 해당 레벨에 맞는 문제 목록
+     */
+    public List<TestQuestionResponseDto> getLevelTests(Grade selectedGrade) {
 
-        List<Test> gradeTestQuestions = testRepository.findByGrade(grade == null? userGrade : grade);
+        if (selectedGrade.equals(Grade.A1) || selectedGrade.equals(Grade.C2))
+            throw new BusinessException(ErrorCode.CANNOT_TAKE_TEST);
+
+        List<Test> gradeTestQuestions = getTests(selectedGrade);
 
         return gradeTestQuestions.stream()
                 .map(TestQuestionResponseDto::toDto)
                 .collect(Collectors.toList());
+    }
+
+
+    /**
+     * 승급 테스트 시 문제 조회
+     * 승급 테스트 자격이 갖추어졌을 때만 응시 가능
+     * 현재 회원이 A2이면 -> B1 문제, B2이면 -> C1 문제 출제
+     * A2: 00점 이상 -> 승급, 00 ~ 00: 유지, 00점 이하: 강등
+     * B1, B2:
+     * C1, C2:
+     * @param provider 현재 회원
+     * @return 해당 레벨에 맞는 문제 리스트
+     */
+    public List<TestQuestionResponseDto> getUpgradeTests(Provider provider) {
+        User user = userService.loadUserByUsername(provider.email());
+        if (!user.isReadyForUpgrade()) throw new BusinessException(ErrorCode.CANNOT_TAKE_TEST);
+
+        Grade nextGrade = Grade.values()[provider.grade().getIndex() + 1];
+
+        List<Test> upgradeTestQuestions = getTests(nextGrade);
+        return upgradeTestQuestions.stream()
+                .map(TestQuestionResponseDto::toDto)
+                .collect(Collectors.toList());
+    }
+
+    // testRepository에서 grade에 맞는 test들을 뽑아 반환해주는 메서드
+    private List<Test> getTests(Grade grade) {
+        List<Test> questions = testRepository.findByGrade(grade);
+        Collections.shuffle(questions);
+        int size;
+        if (grade.equals(Grade.A1) || grade.equals(Grade.A2)) size = 10;
+        else if (grade.equals(Grade.B1) || grade.equals(Grade.B2)) size = 15;
+        else size = 20;
+
+        List<Test> gradeTestQuestions = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            gradeTestQuestions.add(questions.get(i));
+        }
+        return gradeTestQuestions;
     }
 
     /**
@@ -34,7 +89,8 @@ public class TestService {
      * A2: 10문항 -> 60점 이상 통과 (한 문제 당 10점, 6문제 이상 통과)
      * B1~B2: 15문항 -> 70점 이상 통과 (한 문제 당 7점, 10문제 이상 통과)
      * C1: 20문항 -> 80점 이상 통과 (한 문제 당 5점, 16문제 이상 통과)
-     * @param grade 사용자가 지정한 등급
+     *
+     * @param grade           사용자가 지정한 등급
      * @param submitRequestVo 사용자가 제출한 문제, 답안이 들어있는 Vo
      * @return 테스트에 통과했으면 true, 아니면 false
      */
@@ -45,7 +101,7 @@ public class TestService {
             Test test = testRepository.findById(requestDto.getTestId())
                     .orElseThrow(() -> new BusinessException(ErrorCode.TEST_NOT_FOUND));
 
-            if(requestDto.getAnswer().equals(test.getAnswer())) count++;
+            if (requestDto.getAnswer().equals(test.getAnswer())) count++;
         }
 
         return (grade.equals(Grade.A2) && count >= 6) ||

--- a/src/test/java/com/example/ormi5finalteam1/entity/TestTest.java
+++ b/src/test/java/com/example/ormi5finalteam1/entity/TestTest.java
@@ -41,7 +41,7 @@ public class TestTest {
         questions.add(new Test(2L, Grade.A2, "바나나는 영어로?", "banana"));
         when(testRepository.findByGrade(Grade.A2)).thenReturn(questions);
 
-        List<TestQuestionResponseDto> results = testService.getTests(Grade.A1, Grade.A2);
+        List<TestQuestionResponseDto> results = testService.getLevelTests(Grade.A2);
         assertThat(results.get(0).getQuestion()).isEqualTo("파인애플은 영어로?");
         assertThat(results.get(0).getGrade()).isEqualTo(Grade.A2);
     }


### PR DESCRIPTION
## 💡 이슈
resolve #53

## 🤩 개요
레벨/승급 테스트 조회 로직 수정

## 🧑‍💻 작업 사항
- 레벨 테스트 조회 / 승급 테스트 조회 컨트롤러 구분
- 레벨 테스트 조회 시 전달받은 grade 값이 A1, C2이면 Exception 발생
- 올바르지 않은 조회 요청일 때 400 CANNOT_TAKE_TEST Exception 발생하도록 ErrorCode 추가
- 승급 테스트 시 다음 레벨의 값을 알 수 있도록 Grade에 index 필드 추가
- 문제 정보 반환 시에 testId를 같이 반환하도록 수정

## 📖 참고 사항
