### PR TITLE
[Feat] Alan으로부터 문법 예문 쿼리 응답 받아오는 기능 구현

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/external/api/service/AlanAIService.java
+++ b/src/main/java/com/example/ormi5finalteam1/external/api/service/AlanAIService.java
@@ -4,6 +4,7 @@ import com.example.ormi5finalteam1.external.api.client.AlanAIClient;
 import com.example.ormi5finalteam1.external.api.dto.BaseResponse;
 import com.example.ormi5finalteam1.external.api.util.ContentParser;
 import com.example.ormi5finalteam1.external.constants.AlanAIRequestPrompt;
+import com.example.ormi5finalteam1.repository.GrammarExampleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,21 +13,24 @@ import org.springframework.stereotype.Service;
 public class AlanAIService {
   private final AlanAIClient alanAIClient;
   private final ContentParser contentParser;
+  private final GrammarExampleRepository grammarExampleRepository;
 
   public void getGrammarExamplesQuery(AlanAIRequestPrompt prompt, String... grades) {
     // 레벨별로 요청
-    BaseResponse response = alanAIClient.sendRequestToAlanAI(prompt.GRAMMAR_EXAMPLES_INSERT_QUERY, grades);
+    BaseResponse response =
+        alanAIClient.sendRequestToAlanAI(prompt.GRAMMAR_EXAMPLES_INSERT_QUERY, grades);
 
     // 응답 파싱
-    String parsedString = contentParser.parseGrammarExamplesQueryResponse(response.getContent());
+    String rawQuery = contentParser.parseGrammarExamplesQueryResponse(response.getContent());
 
     // 결과 출력
-    if (parsedString != null) {
+    if (rawQuery != null) {
       // todo: 예외처리
     } else {
       // todo: 예외처리
     }
 
     // grammar_examples 테이블에 raw query 날려서 데이터 생성
+    grammarExampleRepository.insertGrammarExampleWithRawQuery(rawQuery);
   }
 }

--- a/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleCustomRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleCustomRepository.java
@@ -1,0 +1,5 @@
+package com.example.ormi5finalteam1.repository;
+
+public interface GrammarExampleCustomRepository {
+  void insertGrammarExampleWithRawQuery(String rawQuery);
+}

--- a/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface GrammarExampleRepository extends JpaRepository<GrammarExample, Long> {
+public interface GrammarExampleRepository extends JpaRepository<GrammarExample, Long>, GrammarExampleCustomRepository {
   Page<GrammarExample> findByQuestionContainingAndGradeOrderByIdAsc(
       String question, Grade grade, Pageable pageable);
 

--- a/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleRepositoryImpl.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/GrammarExampleRepositoryImpl.java
@@ -1,0 +1,16 @@
+package com.example.ormi5finalteam1.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.transaction.annotation.Transactional;
+
+public class GrammarExampleRepositoryImpl implements GrammarExampleCustomRepository {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    @Transactional
+    public void insertGrammarExampleWithRawQuery(String rawQuery) {
+        em.createNativeQuery(rawQuery).executeUpdate();
+    }
+}


### PR DESCRIPTION
## 💡 이슈
resolve #57 

## 🤩 개요
Alan으로부터 문법 예문 쿼리 응답 받아오는 기능 구현

## 🧑‍💻 작업 사항
- 도메인 로직과 관련없는 Alan API 통신이 가능하도록 external에 파일 추가
- Alan API 요청시 client 에러를 400에러로 핸들링하는 exception handler 추가 구현
- GrammarExampleRepository를 AlanAIService에서 주입받아 raw query로 데이터 생성 가능하게 하는 로직 구현

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.
