### PR TITLE
feat(admin): 관리자 - 사용자 비활성화, 계정 삭제, 게시글 삭제, 댓글 삭제 구현

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
@@ -23,8 +23,9 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED(400, "Email is not verified"),
     VERIFICATION_CODE_NOT_FOUND(404, "Verification code not found"),
     VERIFICATION_CODE_EMAIL_MISMATCH(400, "Verification code email is mismatch"),
-    VERIFICATION_CODE_EXPIRED(400, "Verification code is expired");
-
+    VERIFICATION_CODE_EXPIRED(400, "Verification code is expired"),
+    HAS_NO_AUTHORITY(400, "Cannot access due to authority"),
+    ALREADY_DELETED(400, "Already deleted entity");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/AdminController.java
+++ b/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/AdminController.java
@@ -1,0 +1,50 @@
+package com.example.ormi5finalteam1.controller.rest_controller;
+
+import com.example.ormi5finalteam1.common.exception.BusinessException;
+import com.example.ormi5finalteam1.common.exception.ErrorCode;
+import com.example.ormi5finalteam1.domain.user.Provider;
+import com.example.ormi5finalteam1.domain.user.Role;
+import com.example.ormi5finalteam1.service.AdminService;
+import com.example.ormi5finalteam1.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PutMapping("/users/{id}")
+    public void changeUserStatus(@AuthenticationPrincipal Provider provider,
+                                 @PathVariable("id") Long userId) {
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        adminService.changeUserStatus(userId);
+    }
+
+    @DeleteMapping("/users/{id}")
+    public void deleteUser(@AuthenticationPrincipal Provider provider,
+                           @PathVariable("id") Long userId) {
+
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        adminService.deleteUser(userId);
+    }
+
+    @DeleteMapping("/posts/{id}")
+    public void deletePost(@AuthenticationPrincipal Provider provider,
+                           @PathVariable("id") Long postId) {
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        adminService.deletePost(postId);
+    }
+
+    @DeleteMapping("/posts/{postId}/comments/{commentId}")
+    public void deleteComment(@AuthenticationPrincipal Provider provider,
+                              @PathVariable("postId") Long postId,
+                              @PathVariable("commentId") Long commentId) {
+
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        adminService.deleteComment(postId, commentId);
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/user/User.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/user/User.java
@@ -100,6 +100,10 @@ public class User extends BaseEntity implements UserDetails {
         return email;
     }
 
+    public void activateUser() {
+        this.isActive = true;
+    }
+
     public void deactivateUser() {
         this.isActive = false;
     }

--- a/src/main/java/com/example/ormi5finalteam1/repository/CommentRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/CommentRepository.java
@@ -4,10 +4,14 @@ import com.example.ormi5finalteam1.domain.comment.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostIdOrderByCreatedAtAsc(Long id);
     Page<Comment> findByUserIdOrderByCreatedAtDesc(Long id, Pageable pageable);
+
+    Comment findByIdAndPostId(@Param("id") Long commentId,
+                              @Param("postId") Long postId);
 }

--- a/src/main/java/com/example/ormi5finalteam1/service/AdminService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/AdminService.java
@@ -1,0 +1,49 @@
+package com.example.ormi5finalteam1.service;
+
+import com.example.ormi5finalteam1.common.exception.BusinessException;
+import com.example.ormi5finalteam1.common.exception.ErrorCode;
+import com.example.ormi5finalteam1.domain.comment.Comment;
+import com.example.ormi5finalteam1.domain.post.Post;
+import com.example.ormi5finalteam1.domain.user.User;
+import com.example.ormi5finalteam1.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+    private final PostService postService;
+    private final CommentService commentService;
+
+    public void changeUserStatus(Long userId) {
+
+        User normalUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if(normalUser.getDeletedAt() == null) {
+            if (normalUser.isActive()) normalUser.deactivateUser();
+            else normalUser.activateUser();
+        }
+    }
+
+    public void deleteUser(Long userId) {
+
+        User normalUser = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (normalUser.getDeletedAt() == null) normalUser.delete();
+        else throw new BusinessException(ErrorCode.ALREADY_DELETED);
+    }
+
+    public void deletePost(Long postId) {
+        Post foundPost = postService.getPostById(postId);
+        if (foundPost.getDeletedAt() == null) foundPost.delete();
+        else throw new BusinessException(ErrorCode.ALREADY_DELETED);
+    }
+
+    public void deleteComment(Long postId, Long commentId) {
+        commentService.deleteCommentByAdmin(postId, commentId);
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/service/CommentService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/CommentService.java
@@ -69,6 +69,13 @@ public class CommentService {
                 .map(this::convertToDto);
     }
 
+    // 관리자가 댓글을 삭제할 때 호출하는 메서드
+    public void deleteCommentByAdmin(Long postId, Long commentId) {
+        Comment comment = commentRepository.findByIdAndPostId(commentId, postId);
+        if (comment == null) throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND);
+        commentRepository.delete(comment);
+    }
+
     private CommentDto convertToDto(Comment comment) {
         return new CommentDto(
                 comment.getId(),


### PR DESCRIPTION
## 💡 이슈
resolve #155 

## 🤩 개요
관리자 관련 api 개발

## 🧑‍💻 작업 사항
- AdminService, AdminController 추가
- Controller에서 provider.role()이 ADMIN이 아니면 400 HAS_NO_AUTHORITY exception 발생
- 사용자가 activate 상태면 deactivate 하고, deactivate 상태면 activate 함
- 댓글 삭제 로직은 CommentService에 추가
- postId와 commentId로 Comment 객체를 찾는 Query Method를 CommentRepository에 추가
- comment를 찾지 못했으면 404 COMMENT_NOT_FOUND exception 발생
- User, Post 삭제 시 deletedAt이 null이 아니면 400 ALREADY_DELETED exception 발생
- 사용자가 비활성 상태이면 활성화 시키는 activateUser() 메소드를 User Entity에 추가

## 📖 참고 사항
- Comment는 hard delete입니다.
- AdminService의 deleteComment 메소드는 단순히 CommentService의 deleteCommentByAdmin 메소드를 호출합니다.