### PR TITLE
185/admin remain api

### DIFF
--- a/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/ormi5finalteam1/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     HAS_NO_AUTHORITY(400, "Cannot access due to authority"),
     ALREADY_DELETED(400, "Already deleted entity"),
     ALREADY_LIKED(400, "Already liked post"),
-    LIKE_NOT_FOUND(404, "Like not found");
+    LIKE_NOT_FOUND(404, "Like not found"),
+    HAS_ADMIN_AUTHORITY(400, "Account has ADMIN role");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/AdminController.java
+++ b/src/main/java/com/example/ormi5finalteam1/controller/rest_controller/AdminController.java
@@ -2,13 +2,18 @@ package com.example.ormi5finalteam1.controller.rest_controller;
 
 import com.example.ormi5finalteam1.common.exception.BusinessException;
 import com.example.ormi5finalteam1.common.exception.ErrorCode;
+import com.example.ormi5finalteam1.domain.post.dto.AdminPostDetailDto;
+import com.example.ormi5finalteam1.domain.post.dto.AdminPostListDto;
+import com.example.ormi5finalteam1.domain.post.dto.PostDto;
 import com.example.ormi5finalteam1.domain.user.Provider;
 import com.example.ormi5finalteam1.domain.user.Role;
+import com.example.ormi5finalteam1.domain.user.dto.UserInfoDto;
 import com.example.ormi5finalteam1.service.AdminService;
-import com.example.ormi5finalteam1.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +21,13 @@ import org.springframework.web.bind.annotation.*;
 public class AdminController {
 
     private final AdminService adminService;
+
+    @GetMapping("/users")
+    public List<UserInfoDto> getAllUserList(@AuthenticationPrincipal Provider provider) {
+
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        return adminService.getAllUserList();
+    }
 
     @PutMapping("/users/{id}")
     public void changeUserStatus(@AuthenticationPrincipal Provider provider,
@@ -30,6 +42,20 @@ public class AdminController {
 
         if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
         adminService.deleteUser(userId);
+    }
+
+    @GetMapping("/posts")
+    public List<AdminPostListDto> getAllPosts(@AuthenticationPrincipal Provider provider) {
+
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        return adminService.getAllPostList();
+    }
+
+    @GetMapping("/posts/{id}")
+    public AdminPostDetailDto getPostById(@AuthenticationPrincipal Provider provider,
+                                          @PathVariable("id") Long postId) {
+        if (!provider.role().equals(Role.ADMIN)) throw new BusinessException(ErrorCode.HAS_NO_AUTHORITY);
+        return adminService.getPostById(postId);
     }
 
     @DeleteMapping("/posts/{id}")

--- a/src/main/java/com/example/ormi5finalteam1/domain/comment/dto/AdminCommentDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/comment/dto/AdminCommentDto.java
@@ -1,0 +1,26 @@
+package com.example.ormi5finalteam1.domain.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminCommentDto {
+
+    private Long id;
+    private String nickname;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public static AdminCommentDto toDto(CommentDto comment){
+        return AdminCommentDto.builder()
+                .id(comment.getId())
+                .nickname(comment.getNickname())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/post/Post.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/post/Post.java
@@ -34,8 +34,8 @@ public class Post extends BaseEntity {
     @Column(name= "view_count", nullable = false)
     private int viewCount = 0;
 
-    /*@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments;*/
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Like> likes;

--- a/src/main/java/com/example/ormi5finalteam1/domain/post/Post.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/post/Post.java
@@ -34,8 +34,8 @@ public class Post extends BaseEntity {
     @Column(name= "view_count", nullable = false)
     private int viewCount = 0;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments;
+    /*@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments;*/
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Like> likes;

--- a/src/main/java/com/example/ormi5finalteam1/domain/post/dto/AdminPostDetailDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/post/dto/AdminPostDetailDto.java
@@ -1,0 +1,32 @@
+package com.example.ormi5finalteam1.domain.post.dto;
+
+import com.example.ormi5finalteam1.domain.comment.dto.AdminCommentDto;
+import com.example.ormi5finalteam1.domain.post.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminPostDetailDto {
+
+    private String nickname;
+    private String title;
+    private int viewCount;
+    private List<AdminCommentDto> comments;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+
+    public static AdminPostDetailDto toDto (Post post, List<AdminCommentDto> comments) {
+        return AdminPostDetailDto.builder()
+                .nickname(post.getUser().getNickname())
+                .title(post.getTitle())
+                .viewCount(post.getViewCount())
+                .comments(comments)
+                .createdAt(post.getCreatedAt())
+                .deletedAt(post.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/post/dto/AdminPostListDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/post/dto/AdminPostListDto.java
@@ -1,0 +1,30 @@
+package com.example.ormi5finalteam1.domain.post.dto;
+
+import com.example.ormi5finalteam1.domain.post.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminPostListDto {
+
+    private Long id;
+    private String nickname;
+    private String title;
+    private int viewCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+
+    public static AdminPostListDto toDto(Post post) {
+        return AdminPostListDto.builder()
+                .id(post.getId())
+                .nickname(post.getUser().getNickname())
+                .title(post.getTitle())
+                .viewCount(post.getViewCount())
+                .createdAt(post.getCreatedAt())
+                .deletedAt(post.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/com/example/ormi5finalteam1/domain/user/dto/UserInfoDto.java
@@ -1,0 +1,37 @@
+package com.example.ormi5finalteam1.domain.user.dto;
+
+import com.example.ormi5finalteam1.domain.Grade;
+import com.example.ormi5finalteam1.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserInfoDto {
+
+    private Long userId;
+    private String email;
+    private String nickname;
+    private boolean isActivate;
+    private int level;
+    private boolean isReadyForUpgrade;
+    private LocalDateTime createdAt;
+    private LocalDateTime lastLoginedAt;
+    private LocalDateTime deletedAt;
+
+    public static UserInfoDto toDto(User user) {
+        return UserInfoDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .isActivate(user.isActive())
+                .level(user.getLevel())
+                .isActivate(user.isReadyForUpgrade())
+                .createdAt(user.getCreatedAt())
+                .lastLoginedAt(user.getLastLoginedAt())
+                .deletedAt(user.getDeletedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ormi5finalteam1/repository/UserRepository.java
+++ b/src/main/java/com/example/ormi5finalteam1/repository/UserRepository.java
@@ -1,8 +1,13 @@
 package com.example.ormi5finalteam1.repository;
 
+import com.example.ormi5finalteam1.domain.user.Role;
 import com.example.ormi5finalteam1.domain.user.User;
+
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import static com.example.ormi5finalteam1.domain.user.Role.ADMIN;
 
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
@@ -10,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Boolean existsByEmail(String email);
 
   Boolean existsByNickname(String nickname);
+
+  List<User> findAllByOrderByRoleAscId();
 }

--- a/src/main/java/com/example/ormi5finalteam1/service/PostService.java
+++ b/src/main/java/com/example/ormi5finalteam1/service/PostService.java
@@ -13,11 +13,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class PostService {
     private final PostRepository postRepository;
     private final UserService userService;
-
     public PostService(PostRepository postRepository, UserService userService) {
         this.postRepository = postRepository;
         this.userService = userService;
@@ -96,6 +98,18 @@ public class PostService {
         return postRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
     }
+
+    // 관리자가 전체 게시글 조회 시 호출되는 메서드
+    public List<Post> getAllPostsByAdmin() {
+        return postRepository.findAll();
+    }
+
+    // 관리자가 게시글 상세 조회시 호출되는 메서드
+    public Post getPostByAdmin(Long postId) {
+
+        return postRepository.findById(postId).orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
+    }
+
 
     private PostDto convertToDto(Post post) {
         return new PostDto(


### PR DESCRIPTION
## 💡 이슈
resolve #185 

## 🤩 개요
관리자 남은 api 개발

## 🧑‍💻 작업 사항
- 관리자의 전체 유저 조회, 전체 게시글 조회, 게시글 상세 조회 기능 작성
- 유저는 정지/삭제된 유저까지, 게시글은 삭제된 게시글까지 반환
- 게시글 상세 조회에서 해당 게시글의 댓글까지 같이 반환
- 유저를 정지/삭제할 때, 해당 유저가 관리자이면 400 HAS_ADMIN_AUTHORITY를 반환하도록 추가

## 📖 참고 사항
유저 전체 목록 조회할 때, 피그마엔 없지만 계정 탈퇴여부를 나타내는 deletedAt 필드를 추가했습니다.
